### PR TITLE
Persist CQT device

### DIFF
--- a/pesto/utils.py
+++ b/pesto/utils.py
@@ -9,7 +9,7 @@ from .model import PESTOEncoder
 
 
 def load_dataprocessor(step_size, device: Optional[torch.device] = None):
-    return DataProcessor(step_size=step_size, device=device, **cqt_args).to(device)
+    return DataProcessor(step_size=step_size, **cqt_args).to(device)
 
 
 def load_model(model_name: str, device: Optional[torch.device] = None) -> PESTOEncoder:


### PR DESCRIPTION
Closes #17

Opted to remove the `device` parameter from `DataProcessor` constructor and let device management take place through `nn.Module`. Sampling rate can now be passed in constructor, and an initial set of CQT kernels are computed. These are updated, with device persisting, whenever sampling rate is changed.