### PR TITLE
ONNX PESTO export

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ pesto/old_weights
 **/*.png
 **/*.pdf
 **/*.pt
+**/*.onnx

--- a/pesto/model.py
+++ b/pesto/model.py
@@ -256,7 +256,7 @@ class PESTO(nn.Module):
             confidence = confidence.view(batch_size, -1)
             vol = vol.view(batch_size, -1)
 
-        activations = activations.roll(-round(self.shift.cpu().item() * self.bins_per_semitone), -1)
+        activations = activations.roll(-torch.round(self.shift * self.bins_per_semitone).int().item(), -1)
 
         preds = reduce_activations(activations, reduction=self.reduction)
 

--- a/realtime/export_jit.py
+++ b/realtime/export_jit.py
@@ -1,10 +1,9 @@
 import torch
 import argparse
-import datetime
 from pesto import load_model
 
 
-def export_model(checkpoint_name, sampling_rate, chunk_size, script_name):
+def export_model(checkpoint_name, sampling_rate, chunk_size, script_name, batch_size):
     """Exports a model using torch.jit.trace and saves it to a file."""
     step_size = 1000 * chunk_size / sampling_rate
 
@@ -15,12 +14,13 @@ def export_model(checkpoint_name, sampling_rate, chunk_size, script_name):
         step_size=step_size,
         sampling_rate=sampling_rate,
         streaming=True,
-        max_batch_size=4
+        max_batch_size=batch_size,
+        mirror=1.0,
     )
     model.eval()  # Set the model to evaluation mode
 
     # Example input for tracing
-    example_input = torch.randn(3, chunk_size).clip(-1, 1)
+    example_input = torch.randn(batch_size, chunk_size).clip(-1, 1)
 
     # Export the model using torch.jit.trace
     traced_model = torch.jit.trace(model, example_input)
@@ -32,12 +32,12 @@ def export_model(checkpoint_name, sampling_rate, chunk_size, script_name):
     return model, script_name
 
 
-def validate_model(original_model, script_name, chunk_size):
+def validate_model(original_model, script_name, chunk_size, batch_size):
     """Loads the exported model and validates its output."""
     loaded_model = torch.jit.load(script_name)
     loaded_model.eval()
 
-    example_input = torch.randn(2, chunk_size).clip(-1, 1)
+    example_input = torch.randn(batch_size, chunk_size).clip(-1, 1)
 
     # Run the original and loaded models
     with torch.no_grad():
@@ -45,7 +45,9 @@ def validate_model(original_model, script_name, chunk_size):
         traced_output = loaded_model(example_input)
 
     # Compare outputs
-    for name, x1, x2 in zip(["pred", "conf", "vol", "act"], original_output, traced_output):
+    for name, x1, x2 in zip(
+        ["pred", "conf", "vol", "act"], original_output, traced_output
+    ):
         if torch.allclose(x1, x2):
             print(name, ":", x1.shape, "\n", "Test passed: Outputs are close.\n")
         else:
@@ -53,18 +55,50 @@ def validate_model(original_model, script_name, chunk_size):
 
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser(description="Export a model using torch.jit.trace and validate its outputs.")
-    parser.add_argument("checkpoint_name", type=str, help="Checkpoint name for loading the model.")
-    parser.add_argument("-r", "--sampling_rate", type=int, default=48000, help="Sampling rate of the model.")
-    parser.add_argument("-c", "--chunk_size", type=int, default=960, help="Chunk size for processing.")
-    parser.add_argument("-s", "--script_name", type=str, default=None, help="Optional custom script name.")
+    parser = argparse.ArgumentParser(
+        description="Export a model using torch.jit.trace and validate its outputs."
+    )
+    parser.add_argument(
+        "checkpoint_name", type=str, help="Checkpoint name for loading the model."
+    )
+    parser.add_argument(
+        "-r",
+        "--sampling_rate",
+        type=int,
+        default=48000,
+        help="Sampling rate of the model.",
+    )
+    parser.add_argument(
+        "-c", "--chunk_size", type=int, default=960, help="Chunk size for processing."
+    )
+    parser.add_argument(
+        "-s",
+        "--script_name",
+        type=str,
+        default=None,
+        help="Optional custom script name.",
+    )
+    parser.add_argument(
+        "-b",
+        "--batch_size",
+        type=int,
+        default=2,
+        help="Max batch size for processing (default: 2).",
+    )
 
     args = parser.parse_args()
 
     # Construct default script name if not provided
     if args.script_name is None:
-        date_str = datetime.datetime.now().strftime("%y%m%d")
-        args.script_name = f"{date_str}_sr{args.sampling_rate//1000}k_h{args.chunk_size}.pt"
+        args.script_name = (
+            f"{args.checkpoint_name}_{args.sampling_rate}_{args.chunk_size}.pt"
+        )
 
-    model, script_name = export_model(args.checkpoint_name, args.sampling_rate, args.chunk_size, args.script_name)
-    validate_model(model, script_name, args.chunk_size)
+    model, script_name = export_model(
+        args.checkpoint_name,
+        args.sampling_rate,
+        args.chunk_size,
+        args.script_name,
+        args.batch_size,
+    )
+    validate_model(model, script_name, args.chunk_size, args.batch_size)

--- a/realtime/export_onnx.py
+++ b/realtime/export_onnx.py
@@ -1,0 +1,180 @@
+import torch
+import argparse
+import numpy as np
+import onnx
+import onnxruntime as ort
+
+from pesto import load_model
+from realtime.onnx_wrapper import StatelessPESTO
+
+
+def export_model(checkpoint_name, sampling_rate, chunk_size, script_name, batch_size):
+    """Exports a model using ONNX with proper cache state management."""
+    step_size = 1000 * chunk_size / sampling_rate
+
+    print("Chunk size:", chunk_size)
+
+    # Load the original model
+    model = load_model(
+        checkpoint_name,
+        step_size=step_size,
+        sampling_rate=sampling_rate,
+        streaming=True,
+        max_batch_size=batch_size,
+        mirror=1.0,
+    )
+    model.eval()
+
+    # Wrap it with the stateless wrapper
+    stateless_model = StatelessPESTO(model)
+    stateless_model.eval()
+
+    # Example inputs for tracing
+    example_audio = torch.randn(batch_size, chunk_size).clip(-1, 1)
+    example_cache = stateless_model.init_cache(batch_size=batch_size, device="cpu")
+
+    print(f"Cache size: {example_cache.numel()} elements")
+    print(f"Audio input shape: {example_audio.shape}")
+
+    # Export the model using torch.onnx.export
+    torch.onnx.export(
+        stateless_model,
+        (example_audio, example_cache),
+        script_name,
+        input_names=["audio", "cache"],
+        output_names=[
+            "prediction",
+            "confidence",
+            "volume",
+            "activations",
+            "cache_out",
+        ],
+        dynamic_axes={
+            "audio": {0: "batch_size", 1: "audio_length"},
+            "prediction": {0: "batch_size", 1: "time_steps"},
+            "confidence": {0: "batch_size", 1: "time_steps"},
+            "volume": {0: "batch_size", 1: "time_steps"},
+            "activations": {0: "batch_size", 1: "time_steps"},
+        },
+    )
+
+    print(f"Model successfully exported as '{script_name}'")
+    return stateless_model, script_name
+
+
+def validate_model(checkpoint_name, sampling_rate, script_name, chunk_size, batch_size):
+    """Loads the exported model and validates its output using a torch model."""
+    loaded_model = onnx.load(script_name)
+    onnx.checker.check_model(loaded_model)
+
+    print("ONNX model validation successful!")
+    print(
+        f"Model has {len(loaded_model.graph.input)} input(s) and {len(loaded_model.graph.output)} output(s)"
+    )
+
+    # Print input/output info
+    for i, input_info in enumerate(loaded_model.graph.input):
+        print(f"Input {i}: {input_info.name}")
+
+    for i, output_info in enumerate(loaded_model.graph.output):
+        print(f"Output {i}: {output_info.name}")
+
+    # Create ONNX Runtime session
+    session = ort.InferenceSession(script_name)
+
+    # Load a model for comparison
+    step_size = 1000 * chunk_size / sampling_rate
+    torch_model = load_model(
+        checkpoint_name,
+        step_size=step_size,
+        sampling_rate=sampling_rate,
+        streaming=True,
+        max_batch_size=batch_size,
+        mirror=1.0,
+    )
+    torch_model.eval()
+
+    example_input = torch.randn(batch_size, chunk_size).clip(-1, 1)
+
+    # Run the normal PyTorch model (no external cache management)
+    with torch.no_grad():
+        pytorch_output = torch_model(example_input)
+
+    # Create dummy cache state for ONNX (zeros)
+    cache_size = session.get_inputs()[1].shape[1]
+    cache_state = torch.zeros((batch_size, cache_size), dtype=torch.float32)
+
+    # Convert to numpy for ONNX
+    onnx_output = session.run(
+        None,
+        {"audio": example_input.numpy(), "cache": cache_state.numpy()},
+    )
+
+    # Compare outputs
+    output_names = ["pred", "conf", "vol", "act"]
+    onnx_comparison_outputs = onnx_output[:4]  # Skip cache_out for comparison
+    for name, torch_out, onnx_out in zip(
+        output_names, pytorch_output, onnx_comparison_outputs
+    ):
+        torch_out_np = torch_out.cpu().numpy()
+        if np.allclose(torch_out_np, onnx_out, rtol=1e-4, atol=1e-5):
+            print(name, ":", torch_out.shape, "\n", "Test passed: Outputs are close.\n")
+        else:
+            max_diff = np.max(np.abs(torch_out_np - onnx_out))
+            print(f"{name}: Test failed: Max diff = {max_diff:.6f}")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Export a model using ONNX and validate its outputs."
+    )
+    parser.add_argument(
+        "checkpoint_name", type=str, help="Checkpoint name for loading the model."
+    )
+    parser.add_argument(
+        "-r",
+        "--sampling_rate",
+        type=int,
+        default=48000,
+        help="Sampling rate of the model.",
+    )
+    parser.add_argument(
+        "-c", "--chunk_size", type=int, default=960, help="Chunk size for processing."
+    )
+    parser.add_argument(
+        "-s",
+        "--script_name",
+        type=str,
+        default=None,
+        help="Optional custom script name.",
+    )
+    parser.add_argument(
+        "-b",
+        "--batch_size",
+        type=int,
+        default=2,
+        help="Max batch size for the ONNX model (default: 2).",
+    )
+
+    args = parser.parse_args()
+
+    # Construct default script name if not provided
+    if args.script_name is None:
+        args.script_name = (
+            f"{args.checkpoint_name}_{args.sampling_rate}_{args.chunk_size}.onnx"
+        )
+
+    model, script_name = export_model(
+        args.checkpoint_name,
+        args.sampling_rate,
+        args.chunk_size,
+        args.script_name,
+        args.batch_size,
+    )
+    validate_model(
+        args.checkpoint_name,
+        args.sampling_rate,
+        script_name,
+        args.chunk_size,
+        args.batch_size,
+    )

--- a/realtime/onnx_wrapper.py
+++ b/realtime/onnx_wrapper.py
@@ -1,0 +1,111 @@
+"""
+ONNX wrapper for PESTO model that manages cache state explicitly.
+ONNX Runtime is stateless, so we need to externalize the cache state.
+"""
+
+import math
+from typing import Dict, Tuple
+import torch
+import torch.nn as nn
+from pesto.utils.cached_conv import CachedConv1d
+
+
+class StatelessPESTO(nn.Module):
+    """
+    Wrapper for PESTO model to work with ONNX Runtime by managing cache state explicitly.
+
+    This wrapper extracts the cache state from the model's cached convolutions,
+    returns it as an output, and accepts it as an input for the next inference.
+    """
+
+    def __init__(self, model):
+        super().__init__()
+        self.model = model
+        self.cache_size_dict = self.get_cache_names()
+        self.cache_size = sum([math.prod(v) for v in self.cache_size_dict.values()])
+
+    def get_cache_names(self) -> Dict[str, Tuple[int]]:
+        """Get information about all cached modules and their cache shapes."""
+        cache_size_dict: Dict[str, Tuple[int]] = {}
+
+        for name, m in self.model.named_modules():
+            if isinstance(m, CachedConv1d):
+                # CachedConv1d has a CachedPadding1d as its cache attribute
+                if hasattr(m.cache, "pad"):
+                    # Store the full shape for proper reconstruction
+                    cache_size_dict[name + "-cache"] = tuple(m.cache.pad.shape)
+
+        return cache_size_dict
+
+    def gather_caches(self, batch_size: int = 1) -> torch.Tensor:
+        """Gather all cache tensors into a single flattened tensor."""
+        cache_tensors = []
+
+        for name, m in self.model.named_modules():
+            if isinstance(m, CachedConv1d):
+                if hasattr(m.cache, "pad"):
+                    # Flatten the entire cache tensor
+                    c = m.cache.pad.flatten()
+                    cache_tensors.append(c)
+
+        if cache_tensors:
+            cache_tensor = torch.cat(cache_tensors, dim=0)
+            # Repeat to match batch size - separate cache state for each sample
+            return cache_tensor.unsqueeze(0).expand(batch_size, -1)
+        else:
+            # Return empty tensor if no caches
+            return torch.empty(batch_size, 0)
+
+    def set_caches(self, cache: torch.Tensor) -> None:
+        """Set all cache tensors from a single flattened tensor."""
+        if cache.numel() == 0:
+            return
+
+        # Use the first sample's cache state (batch dimension 0)
+        # All samples in a batch share the same cache state during inference
+        cache_flat = cache[0]  # Shape: (cache_size,)
+        cache_pointer = 0
+
+        for name, m in self.model.named_modules():
+            if isinstance(m, CachedConv1d):
+                if hasattr(m.cache, "pad"):
+                    shape = self.cache_size_dict[name + "-cache"]
+                    c_numel = math.prod(shape)
+
+                    # Extract the cache slice and reshape to original shape
+                    cache_slice = cache_flat[cache_pointer : cache_pointer + c_numel]
+                    m.cache.pad = cache_slice.view(shape)
+
+                    cache_pointer = cache_pointer + c_numel
+
+    def forward(
+        self, audio: torch.Tensor, cache: torch.Tensor
+    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+        """
+        Forward pass that manages cache state explicitly.
+
+        Args:
+            audio: Input audio tensor
+            cache: Flattened cache state from previous inference
+
+        Returns:
+            Tuple of (prediction, confidence, volume, activations, cache_out)
+        """
+        # Set the cache state
+        self.set_caches(cache)
+
+        # Run the model
+        model_output = self.model(audio)
+        preds, confidence, vol, activations = model_output
+
+        # Gather the updated cache state
+        batch_size = audio.shape[0]
+        cache_out = self.gather_caches(batch_size)
+
+        return preds, confidence, vol, activations, cache_out
+
+    def init_cache(self, batch_size: int = 1, device: str = "cpu") -> torch.Tensor:
+        """Initialize cache state with zeros."""
+        if self.cache_size == 0:
+            return torch.empty(batch_size, 0, device=device)
+        return torch.zeros(batch_size, self.cache_size, device=device)

--- a/realtime/speed_onnx.py
+++ b/realtime/speed_onnx.py
@@ -1,0 +1,55 @@
+import argparse
+import time
+import numpy as np
+import onnxruntime as ort
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="Benchmark an ONNX model.")
+    parser.add_argument("onnx_model", type=str, help="Path to the ONNX model file.")
+    parser.add_argument(
+        "-b", "--batch_size", type=int, default=1, help="Batch size for inference."
+    )
+    parser.add_argument(
+        "-c", "--chunk_size", type=int, default=256, help="Size of audio chunks."
+    )
+    return parser.parse_args()
+
+
+def benchmark_model(onnx_model, batch_size, chunk_size, num_iterations=5000):
+    # Load the exported ONNX model
+    session = ort.InferenceSession(onnx_model)
+
+    example_audio = (
+        np.random.randn(batch_size, chunk_size).clip(-1, 1).astype(np.float32)
+    )
+
+    # Initialize cache state for the ONNX model
+    cache_state = np.zeros(
+        (batch_size, session.get_inputs()[1].shape[1]), dtype=np.float32
+    )
+
+    # Measure inference time
+    t_list = []
+    for _ in range(num_iterations):
+        outputs = session.run(
+            None, {"audio": example_audio, "cache": cache_state}
+        )
+        # Update cache state for next iteration
+        cache_state = outputs[4]  # cache_out is the 5th output (index 4)
+        t_list.append(time.time())
+
+    t_list = np.array(t_list, dtype=np.float64)
+    it = t_list[1:] - t_list[:-1]
+
+    print("Compute time per chunk:")
+    print(f"\t{1000 * it.mean():.3f} ± {1000 * it.std():.3f} ms")
+
+    it = 1 / it
+    print("FPS:")
+    print(f"\t{it.mean():.3f} ± {it.std():.3f} FPS")
+
+
+if __name__ == "__main__":
+    args = parse_args()
+    benchmark_model(args.onnx_model, args.batch_size, args.chunk_size)

--- a/realtime/test_acc.py
+++ b/realtime/test_acc.py
@@ -1,0 +1,186 @@
+import os
+import argparse
+import numpy as np
+import torch
+import onnxruntime as ort
+import torchaudio
+import matplotlib.pyplot as plt
+from pesto import load_model
+
+# Default checkpoint name
+CHECKPOINT = "mir-1k_g7"
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description="Test accuracy across PyTorch, TorchScript, and ONNX models"
+    )
+    parser.add_argument(
+        "-r",
+        "--sampling_rate",
+        type=int,
+        default=44100,
+        help="Sampling rate (default: 44100)",
+    )
+    parser.add_argument(
+        "-c", "--chunk_size", type=int, default=1024, help="Chunk size (default: 1024)"
+    )
+    return parser.parse_args()
+
+
+def load_audio(target_sr):
+    """Load and preprocess test audio."""
+    audio, sr = torchaudio.load("tests/audios/example.wav")
+    if sr != target_sr:
+        audio = torchaudio.transforms.Resample(sr, target_sr)(audio)
+    if audio.shape[0] > 1:
+        audio = torch.mean(audio, dim=0, keepdim=True)
+    return audio[0].numpy().astype(np.float32), target_sr
+
+
+def process_chunks(audio, chunk_size, hop_size=None):
+    """Split audio into chunks."""
+    if hop_size is None:
+        hop_size = chunk_size
+    chunks = []
+    for i in range(0, len(audio) - chunk_size + 1, hop_size):
+        chunks.append(audio[i : i + chunk_size])
+    return np.array(chunks)
+
+
+def run_model(model_type, chunks, sr, chunk_size):
+    """Run model inference on chunks."""
+    results = []
+
+    if model_type == "pytorch":
+        step_size = chunk_size / sr * 1000
+        model = load_model(
+            CHECKPOINT,
+            step_size=step_size,
+            sampling_rate=sr,
+            streaming=True,
+            mirror=1.0,
+        )
+        model.eval()
+
+        with torch.no_grad():
+            for chunk in chunks:
+                pred, conf, vol, _ = model(torch.from_numpy(chunk).unsqueeze(0))
+                results.append([pred[0, 0].item(), conf[0, 0].item(), vol[0, 0].item()])
+
+    elif model_type == "torchscript":
+        model_path = f"{CHECKPOINT}_{sr}_{chunk_size}.pt"
+        if not os.path.exists(model_path):
+            print(f"TorchScript model not found: {model_path}")
+            return None
+
+        model = torch.jit.load(model_path)
+        model.eval()
+
+        with torch.no_grad():
+            for chunk in chunks:
+                pred, conf, vol, _ = model(torch.from_numpy(chunk).unsqueeze(0))
+                results.append([pred[0, 0].item(), conf[0, 0].item(), vol[0, 0].item()])
+
+    elif model_type == "onnx":
+        model_path = f"{CHECKPOINT}_{sr}_{chunk_size}.onnx"
+        if not os.path.exists(model_path):
+            print(f"ONNX model not found: {model_path}")
+            return None
+
+        session = ort.InferenceSession(model_path)
+        cache_state = np.zeros((1, session.get_inputs()[1].shape[1]), dtype=np.float32)
+
+        for chunk in chunks:
+            outputs = session.run(
+                None,
+                {"audio": chunk.reshape(1, -1), "cache": cache_state},
+            )
+            results.append([outputs[0][0, 0], outputs[1][0, 0], outputs[2][0, 0]])
+            cache_state = outputs[4]  # cache_out
+
+    return np.array(results)
+
+
+def main():
+    args = parse_args()
+
+    print(f"Loading audio (target SR: {args.sampling_rate}Hz)...")
+    audio, sr = load_audio(args.sampling_rate)
+    chunks = process_chunks(audio, args.chunk_size)
+    print(f"Processing {len(chunks)} chunks of size {args.chunk_size}...")
+
+    # Run all available models
+    model_results = {}
+
+    # PyTorch (always available)
+    print("Running PyTorch model...")
+    pytorch_results = run_model("pytorch", chunks, sr, args.chunk_size)
+    model_results["PyTorch"] = pytorch_results
+
+    # TorchScript (check if exists)
+    print("Running TorchScript model...")
+    torchscript_results = run_model("torchscript", chunks, sr, args.chunk_size)
+    if torchscript_results is not None:
+        model_results["TorchScript"] = torchscript_results
+
+    # ONNX (check if exists)
+    print("Running ONNX model...")
+    onnx_results = run_model("onnx", chunks, sr, args.chunk_size)
+    if onnx_results is not None:
+        model_results["ONNX"] = onnx_results
+
+    if len(model_results) < 2:
+        print("Need at least 2 models to compare. Exiting.")
+        return
+
+    # Convert to Hz and calculate differences
+    def midi_to_hz(midi):
+        return 440 * (2 ** ((midi - 69) / 12))
+
+    model_hz = {}
+    for name, results in model_results.items():
+        model_hz[name] = midi_to_hz(results[:, 0])
+
+    # Create clean plot
+    time_axis = np.arange(len(chunks)) * args.chunk_size / sr
+
+    plt.figure(figsize=(12, 6))
+
+    # Pitch predictions
+    plt.subplot(2, 1, 1)
+    colors = ["b-", "r-", "g--", "m:", "c-"]
+    for i, (name, results) in enumerate(model_results.items()):
+        plt.plot(time_axis, results[:, 0], colors[i], label=name, alpha=0.8)
+    plt.ylabel("MIDI Note")
+    plt.title("Pitch Predictions")
+    plt.legend()
+    plt.grid(True, alpha=0.3)
+
+    # Confidence values
+    plt.subplot(2, 1, 2)
+    for i, (name, results) in enumerate(model_results.items()):
+        plt.plot(time_axis, results[:, 1], colors[i], label=name, alpha=0.8)
+    plt.xlabel("Time (s)")
+    plt.ylabel("Confidence")
+    plt.title("Confidence Values")
+    plt.legend()
+    plt.grid(True, alpha=0.3)
+
+    plt.tight_layout()
+    plt.savefig("accuracy_comparison.png", dpi=150)
+    plt.show()
+
+    # Print accuracy summary
+    print("\nAccuracy Summary:")
+    model_names = list(model_results.keys())
+    for i in range(len(model_names)):
+        for j in range(i + 1, len(model_names)):
+            name1, name2 = model_names[i], model_names[j]
+            hz1, hz2 = model_hz[name1], model_hz[name2]
+            avg_diff = np.mean(np.abs(hz1 - hz2))
+            print(f"{name1} vs {name2}: {avg_diff:.3f} Hz avg")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_jit.py
+++ b/tests/test_jit.py
@@ -7,12 +7,11 @@ import torch
 from .utils import generate_synth_data
 
 
-DATE = "250217"
-SAMPLE_RATE = 48000
-HOP = 256
+SAMPLE_RATE = 44100
+HOP = 1024
 BATCHED = True
 MARGIN = 8192 // (2 * HOP)
-SCRIPT_PATH = f"realtime/{DATE}_sr{SAMPLE_RATE // 1000:d}k_h{HOP:d}.pt"
+SCRIPT_PATH = f"mir-1k_g7_{SAMPLE_RATE}_{HOP}.pt"
 
 
 @pytest.fixture
@@ -20,8 +19,10 @@ def model():
     return torch.jit.load(SCRIPT_PATH)
 
 
-@pytest.mark.skipif(not os.path.exists(SCRIPT_PATH), reason="Script path does not exist")
-@pytest.mark.parametrize('pitch', range(50, 80))
+@pytest.mark.skipif(
+    not os.path.exists(SCRIPT_PATH), reason="Script path does not exist"
+)
+@pytest.mark.parametrize("pitch", range(50, 80))
 def test_performances(model, pitch):
     x = generate_synth_data(pitch, sr=SAMPLE_RATE)
     if BATCHED:
@@ -32,11 +33,13 @@ def test_performances(model, pitch):
     # remove first elems of the audio
     preds = preds[..., MARGIN:]
 
-    torch.testing.assert_allclose(preds, torch.full_like(preds, pitch), atol=0.1, rtol=0.1)
+    torch.testing.assert_close(preds, torch.full_like(preds, pitch), atol=0.1, rtol=0.1)
 
 
-@pytest.mark.skipif(not os.path.exists(SCRIPT_PATH), reason="Script path does not exist")
-@pytest.mark.parametrize('pitch', range(50, 80))
+@pytest.mark.skipif(
+    not os.path.exists(SCRIPT_PATH), reason="Script path does not exist"
+)
+@pytest.mark.parametrize("pitch", range(50, 80))
 def test_streaming(model, pitch):
     x = generate_synth_data(pitch, duration=1000 * HOP / SAMPLE_RATE, sr=SAMPLE_RATE)
     if BATCHED:
@@ -50,4 +53,4 @@ def test_streaming(model, pitch):
     preds = torch.cat(preds, dim=int(BATCHED))
     preds = preds[..., MARGIN:]
 
-    torch.testing.assert_allclose(preds, torch.full_like(preds, pitch), atol=0.1, rtol=0.1)
+    torch.testing.assert_close(preds, torch.full_like(preds, pitch), atol=0.1, rtol=0.1)

--- a/tests/test_onnx.py
+++ b/tests/test_onnx.py
@@ -1,0 +1,65 @@
+import os.path
+
+import pytest
+
+import numpy as np
+import onnxruntime as ort
+
+from .utils import generate_synth_data
+
+
+SAMPLE_RATE = 44100
+HOP = 1024
+BATCHED = True
+MARGIN = 8192 // (2 * HOP)
+ONNX_PATH = f"mir-1k_g7_{SAMPLE_RATE}_{HOP}.onnx"
+
+
+@pytest.fixture
+def model():
+    session = ort.InferenceSession(ONNX_PATH)
+    return session
+
+
+@pytest.mark.skipif(not os.path.exists(ONNX_PATH), reason="ONNX path does not exist")
+@pytest.mark.parametrize("pitch", range(50, 80))
+def test_performances(model, pitch):
+    x = generate_synth_data(pitch, sr=SAMPLE_RATE)
+    if BATCHED:
+        x = x.unsqueeze(0)
+
+    # Initialize cache state for the ONNX model
+    cache_state = np.zeros((1, model.get_inputs()[1].shape[1]), dtype=np.float32)
+
+    outputs = model.run(None, {"audio": x.numpy(), "cache": cache_state})
+    preds = outputs[0]  # First output is predictions
+
+    # remove first elems of the audio
+    preds = preds[..., MARGIN:]
+
+    expected = np.full_like(preds, pitch)
+    np.testing.assert_allclose(preds, expected, atol=0.1, rtol=0.1)
+
+
+@pytest.mark.skipif(not os.path.exists(ONNX_PATH), reason="ONNX path does not exist")
+@pytest.mark.parametrize("pitch", range(50, 80))
+def test_streaming(model, pitch):
+    x = generate_synth_data(pitch, duration=1000 * HOP / SAMPLE_RATE, sr=SAMPLE_RATE)
+    if BATCHED:
+        x = x.unsqueeze(0)
+
+    # Initialize cache state for streaming
+    cache_state = np.zeros((1, model.get_inputs()[1].shape[1]), dtype=np.float32)
+
+    preds = []
+    for chunk in x.split(HOP, dim=-1):
+        outputs = model.run(None, {"audio": chunk.numpy(), "cache": cache_state})
+        p = outputs[0]  # predictions
+        cache_state = outputs[4]  # cache_out (5th output)
+        preds.append(p)
+
+    preds = np.concatenate(preds, axis=int(BATCHED))
+    preds = preds[..., MARGIN:]
+
+    expected = np.full_like(preds, pitch)
+    np.testing.assert_allclose(preds, expected, atol=0.1, rtol=0.1)


### PR DESCRIPTION
### Changes
- **Added ONNX export:** New export script with validation. ONNX model runs generally at least 2x as fast on CPU and much more stable, with a ~0.7 ± 0.03 ms inference time. Plus cleaner porting to JS, C++ etc...
- **Created stateless wrapper:** Extracts cache state from VQT buffer for external management to allow for stateless inference
- **Model architecture compatibility:** Substituted unsupported `round()` for `torch.round()` in  `pesto/model.py` and `view_as_complex().abs()` for equivalent manual calculation in `pesto/data.py` to enable ONNX tracing
- **Full batch size and dynamic axes compatibility:** Supports both chunk-by-chunk and entire audio file inference like the original PyTorch model, with flexible batch sizes support similar to JIT
- **Added testing:** ONNX speed benchmarking and TorchScript/ONNX output reproduction comparison tests against PyTorch
- **Fixed default JIT export issue:** Corrected default JIT streaming export configuration to add "mirror=1.0", fixing the non-centred windows adding large output latency 
- **Updated export file paths:** Changed from date-based to checkpoint-based naming convention for better tracking
---
### Usage
Usage is mostly the same as `export_jit.py`
```shell
python -m realtime.export_onnx --help
```
with inference following:
```python
import onnxruntime as ort
import numpy as np

session = ort.InferenceSession("mir-1k_g7_44100_1024.onnx")
cache_size = session.get_inputs()[1].shape[1]  # Get cache size from model
cache_state = np.zeros((batch_size, cache_size), dtype=np.float32)  # Initialize cache

for audio_chunk in audio_chunks:
    outputs = session.run(None, {
        "audio": audio_chunk,
        "cache": cache_state
    })
    prediction, confidence, volume, activations, cache_out = outputs
    cache_state = cache_out  # Update for next iteration
```
This is also included in `README.md`

---
### Output comparison
![accuracy_comparison](https://github.com/user-attachments/assets/c85d922b-270d-4bf4-8060-cbfe3499f13c)

